### PR TITLE
docs: Flag autoloader pre-reading as required in `AGENTS.md` 🗺️📚🚧

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,20 @@ OOP WordPress plugin framework. Auto-loads PHP files by name suffix, routes inst
 
 ---
 
+## Before you write code
+
+This primer is a map, not the territory. Before adding files or editing framework internals, read these — in order — and treat them as required, not optional reference:
+
+| File | Why it's mandatory |
+|------|--------------------|
+| [docs/AUTOLOADER.md](./docs/AUTOLOADER.md) | File naming suffixes are load-bearing. Get them wrong and the autoloader silently skips your file — no error, no instance, just nothing. |
+| [docs/ANTIPATTERNS.md](./docs/ANTIPATTERNS.md) | Catalogue of code that looks right but isn't (static-vs-instance properties on `Route`/`ACF_Block`, `query()` chaining that doesn't exist, `parent::params()` skips, etc.). |
+| [docs/CONVENTIONS.md](./docs/CONVENTIONS.md) | Preferred syntax where multiple forms are valid (e.g. `new My_View([...])` over `My_View::render([...])`). |
+
+Skimming the primer alone produces wrongly-named files, broken subclasses, and silent no-ops. The three docs above are where the framework's failure modes live.
+
+---
+
 ## Class Hierarchy
 
 "Auto-instantiated" means the autoloader creates a singleton instance on load — no manual bootstrapping needed.
@@ -157,6 +171,8 @@ OOP WordPress plugin framework. Auto-loads PHP files by name suffix, routes inst
 ## File Naming
 
 `kebab-case-name.parent-identifier.php` — the parent identifier encodes the inheritance relationship for the autoloader's topological sort.
+
+> ⚠️ **Suffixes are load-bearing, not stylistic.** A file named `my-thing.app.php` is parsed as a subclass of `App`; renaming it to `my-thing-app.php` or `lattice-app.php` makes the autoloader silently ignore it — no error, no instance, no warning. If your class never seems to load, check the suffix first. See [docs/AUTOLOADER.md](./docs/AUTOLOADER.md).
 
 | Identifier | Framework class |
 |------------|----------------|


### PR DESCRIPTION
## What this changes

Adds a "Before you write code" section to `AGENTS.md` directing agents to `AUTOLOADER.md`, `ANTIPATTERNS.md`, and `CONVENTIONS.md` as mandatory reads before touching framework files. Adds a load-bearing-suffixes warning above the File Naming table.

Closes the first item in `lattice-test` ROADMAP: *AGENTS.md — flag autoloader pre-reading as required*.

## Acceptance criteria

- [x] AGENTS.md has a "Before you write code" section listing AUTOLOADER.md, ANTIPATTERNS.md, and CONVENTIONS.md as mandatory reads
- [x] The "File Naming" table gains a one-line warning that suffixes are load-bearing, not stylistic

## Antipatterns checked

N/A — docs-only change.

## Staging exercise

N/A — pure docs change with no runtime surface.

## Submodule bump

- [x] No follow-up needed (docs-only)

## Commit hygiene

- [x] No new files
- [x] Commit message follows `type: description \`Class::method\` 🎭🎪🎠` with 3 storytelling emojis (🗺️📚🚧 — map, books, "wet paint" sign — staking out the trail and warning readers it's wet)

---

🤖 Authored by `nightly-dev` agent (first PR from the loop). Initial push was blocked by the submodule HTTPS origin — fixed by switching to SSH. See [lattice-test#2](https://github.com/perrelet/lattice-test/issues/2) for the original escalation.