### PR TITLE
docs: AUTOLOADER.md — Common Confusions section

### DIFF
--- a/docs/AUTOLOADER.md
+++ b/docs/AUTOLOADER.md
@@ -7,6 +7,7 @@ The Digitalis Framework uses a custom inheritance-aware autoloader that automati
 ## Table of Contents
 
 - [Overview](#overview)
+- [Common Confusions](#common-confusions)
 - [File Naming Convention](#file-naming-convention)
 - [Inheritance Resolution](#inheritance-resolution)
 - [Directory Conventions](#directory-conventions)
@@ -36,6 +37,39 @@ The autoloader is implemented as the `Autoloader` trait, used by the `App` abstr
 | `Autoloader` trait | `include/traits/Autoloader.trait.php` | Main autoloading logic |
 | `App` abstract | `include/objects/App.abstract.php` | Base plugin class using trait |
 | `Auto_Instantiate` trait | `include/traits/auto-instantiate.trait.php` | Default instantiation behavior |
+
+---
+
+## Common Confusions
+
+Five behaviours the autoloader handles invisibly that an agent will get wrong on first contact. Each is a one-line "wrong assumption → reality."
+
+### `$this->path` is the App-subclass file's location, not the plugin root
+
+> **Wrong assumption:** `$this->path` resolves to the plugin root directory.
+> **Reality:** `App::__construct()` sets `$this->path = plugin_dir_path( (new ReflectionClass(static::class))->getFileName() )` — the directory of the App-subclass file itself.
+
+If `my-plugin.app.php` lives at `<plugin>/include/my-plugin.app.php`, `$this->path` is `<plugin>/include/`. The default `autoload()` recurses from that path, so the App-subclass file's location determines the autoload root.
+
+### `.parent.php` suffixes are load-bearing, not stylistic
+
+> **Wrong assumption:** `my-thing-app.php` and `my-thing.app.php` are equivalent.
+> **Reality:** The autoloader parses the dotted suffix to build the inheritance graph and topologically sort load order. A name without a parent identifier is not treated as a subclass definition — the file is silently skipped during inheritance-aware loading. No error, no warning.
+
+### `_dirname/` is skipped during recursive autoload
+
+> **Wrong assumption:** the leading underscore is naming flavour; files inside still load.
+> **Reality:** `autoload()` skips any directory whose name starts with `_`. Use it for code that must be loaded explicitly later (e.g. `_admin/` loaded by the default `load_admin()`, `_cli/` by `load_cli()`).
+
+### `~dirname/` loads only when the matching plugin is active
+
+> **Wrong assumption:** the leading tilde is naming flavour; the directory always loads.
+> **Reality:** The autoloader strips the `~` and matches the remainder against the directory names of active plugins (`get_plugins()` + `is_plugin_active()`). `~woocommerce/` loads only if WooCommerce is active; if the plugin is absent or deactivated, the entire directory is silently ignored — no fatal, no missing-class noise.
+
+### `hello()` and `static_init()` fire after include — no instance required
+
+> **Wrong assumption:** lifecycle hooks need an instance to run.
+> **Reality:** Immediately after `include_once`, the autoloader calls `ClassName::hello()` and then `ClassName::static_init()` if those static methods exist — before any instantiation, regardless of `get_auto_instantiation()`. Use them for static-time registration (`register_post_type()`, hooks bound to `[static::class, '…']`) that doesn't need an instance.
 
 ---
 


### PR DESCRIPTION
## What this changes

Adds a new "Common Confusions" section near the top of `framework/docs/AUTOLOADER.md`, between Overview and File Naming Convention. The section consolidates the five non-obvious autoloader behaviours an agent (or a new human contributor) will get wrong on first contact, each as a one-line "wrong assumption → reality" with a paragraph of context.

Implements the roadmap item: **AUTOLOADER.md — Common Confusions section**.

The five confusions covered:

- `$this->path` is reflected from the App-subclass file's location (not the plugin root)
- `.parent.php` suffix is load-bearing, not stylistic
- `_dirname/` is skipped during recursive autoload
- `~dirname/` is conditional on the matching active plugin
- `hello()` and `static_init()` fire after include with no instantiation needed

## Acceptance criteria

- [x] New "Common Confusions" section near the top of `framework/docs/AUTOLOADER.md` (after Overview, before File Naming Convention) — `docs/AUTOLOADER.md` lines 43–73 in the new file (and a corresponding TOC entry on line 10).
- [x] Covers all five confusions listed in the roadmap acceptance — one `### …` heading per confusion, lines 47–72.
- [x] Each confusion has a one-line "wrong assumption → reality" — every entry leads with a blockquote pairing `**Wrong assumption:**` and `**Reality:**` lines.

## Antipatterns checked

- [x] No bare `WP_Query` / `get_posts()` / `get_users()` / `get_terms()` at call sites — N/A (docs)
- [x] No `wp_update_post` / `wp_update_user` / `wp_update_term` — N/A (docs)
- [x] No raw meta/field/option key strings at call sites — N/A (docs)
- [x] If overriding `View::params()`, `parent::params($p)` is called — N/A (docs)
- [x] If touching `View::$merge`, all parent merge keys are re-listed — N/A (docs)
- [x] `static::` used for inherited static calls, not `self::` — N/A (docs)

## Staging exercise

N/A — pure docs change. No runtime surface modified.

- URL(s) hit: N/A
- What was exercised: N/A
- Result: N/A

## Submodule bump

- [x] No follow-up needed
- [ ] Bump required in lattice-test (note any dependent roadmap items)

## Commit hygiene

- [x] No new files unless required (single-file edit to `docs/AUTOLOADER.md`)
- [x] Commit messages follow `type: description \`Class::method\` 🎭🎪🎠` with 3 storytelling emojis (🗺️🪤💡 — the map flags traps, the lightbulb is the agent finally getting it)