### PR TITLE
docs: Surface `AUTOLOADER.md` Common Confusions in `AGENTS.md` Critical Rules 🪤🪞🗺️

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,6 +468,15 @@ The cached instance state may still hold pre-change values, and a full `save()` 
 
 **Quick reference for the four core model-method traps** — `query()` returns array not builder, `$model->save()` not `wp_update_*`, wrapped accessors not raw keys, vendor-prefixed variable naming — at [MODELS.md#common-confusions](./docs/MODELS.md#common-confusions).
 
+**`App::$path` is the App-subclass file's directory, not the plugin root.**
+`App::__construct()` reflects `static::class` to derive `$this->path`. Move `my-plugin.app.php` from `<plugin>/` to `<plugin>/include/` and the autoload root shifts with it. See [AUTOLOADER.md#common-confusions](./docs/AUTOLOADER.md#common-confusions).
+
+**File-name suffixes are load-bearing, not stylistic.**
+`my-thing.app.php` is parsed as a subclass of `App`; `my-thing-app.php` is silently skipped by the inheritance-aware loader — no error, no warning, no instance. See [AUTOLOADER.md#common-confusions](./docs/AUTOLOADER.md#common-confusions).
+
+**`hello()` and `static_init()` self-fire after include — no instantiation needed.**
+The autoloader calls these static methods immediately after `include_once`, before any instantiation and regardless of `get_auto_instantiation()`. Use them for static-time registration (`register_post_type()`, hooks bound to `[static::class, '…']`) that doesn't need an instance. See [AUTOLOADER.md#common-confusions](./docs/AUTOLOADER.md#common-confusions).
+
 ---
 
 ## Conventions


### PR DESCRIPTION
## What this changes

Retroactive completion of the doc-surfacing pattern for PR #3 (which added a Common Confusions section to `AUTOLOADER.md`). Per the surfacing rule (`.claude/agents/nightly-dev.md` § Doc work — surfacing rule), every sub-doc Common Confusions / antipattern entry should be mirrored as a one-line summary in `AGENTS.md`'s Critical Rules section, linked back to the sub-doc. PR #3 added the depth; this PR adds the pointers, so an agent that only reads `AGENTS.md` still walks away with the trap surface.

Roadmap item: **AUTOLOADER.md — surface Common Confusions in AGENTS.md Critical Rules**

## Acceptance criteria

- [x] AGENTS.md "Critical Rules" gains 2-3 short one-liners drawn from AUTOLOADER.md's Common Confusions, each linked back to that section — three new entries appended to Critical Rules, each ending in `See [AUTOLOADER.md#common-confusions](./docs/AUTOLOADER.md#common-confusions).`
- [x] Cover at minimum: `$this->path` reflected from the App-subclass file's location; `.parent.php` suffix is load-bearing not stylistic; lifecycle hooks (`hello()`, `static_init()`) self-fire after include — all three covered, in that order
- [x] Don't dedupe with existing AGENTS.md rules — pointer + summary is the pattern — kept the existing File Naming warning at line 175 and the new Critical Rules entries side by side, matching the precedent set by the MODELS.md surfacing entries

## Antipatterns checked

- [x] No bare `WP_Query` / `get_posts()` / `get_users()` / `get_terms()` at call sites — N/A (docs-only)
- [x] No `wp_update_post` / `wp_update_user` / `wp_update_term` — N/A (docs-only)
- [x] No raw meta/field/option key strings at call sites — N/A (docs-only)
- [x] If overriding `View::params()`, `parent::params($p)` is called — N/A (docs-only)
- [x] If touching `View::$merge`, all parent merge keys are re-listed — N/A (docs-only)
- [x] `static::` used for inherited static calls, not `self::` — N/A (docs-only)

## Staging exercise

N/A — pure docs change, no runtime surface.

## Submodule bump

- [x] No follow-up needed
- [ ] Bump required in lattice-test (note any dependent roadmap items)

The lattice-test submodule pointer can be bumped opportunistically; no roadmap item depends on this landing first.

## Commit hygiene

- [x] No new files unless required
- [x] Commit messages follow `type: description \`Class::method\` 🎭🎪🎠` with 3 storytelling emojis — 🪤🪞🗺️ : the trap (sub-doc Common Confusion) is mirrored onto the agent's map (AGENTS.md).