### PR TITLE
docs: `VIEW_SYSTEM.md` Common Confusions + `AGENTS.md` surface entries 🪤🪞🎭

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,10 +428,13 @@ Full context and code examples for all of these are in [ANTIPATTERNS.md](./docs/
 `Post::query()->where_meta()` does not exist. Pass `&$wp_query` as the second argument to access `found_posts`.
 
 **`View::$merge` does not accumulate across subclasses.**
-Each child class must re-list all parent merge keys: `['classes', 'styles']`, not just `['styles']`.
+Each child class must re-list all parent merge keys: `['classes', 'styles']`, not just `['styles']`. See [VIEW_SYSTEM.md#common-confusions](./docs/VIEW_SYSTEM.md#common-confusions).
 
 **Always call `parent::params($p)` when overriding `params()`.**
-Skipping it silently drops any param transformations defined in parent classes.
+Skipping it silently drops any param transformations defined in parent classes. Same rule for `__construct()` overrides — always call `parent::__construct($params)` first. See [VIEW_SYSTEM.md#common-confusions](./docs/VIEW_SYSTEM.md#common-confusions).
+
+**Class-string `$defaults` are auto-resolved as DI — opt out with `$skip_inject`.**
+Any `$defaults` value naming a class with `get_instance()` (e.g. `'order' => Order::class`) is treated as a DI signal: the framework calls `Order::get_instance($value)` and replaces the param with the instance. Want the class name to *stay* a literal string? Add the key to `$skip_inject`. See [VIEW_SYSTEM.md#common-confusions](./docs/VIEW_SYSTEM.md#common-confusions).
 
 **`Query_Vars::merge()` combines arrays; `overwrite()` replaces unconditionally.**
 `merge(['post_status' => 'draft'])` on an existing `'publish'` produces `['publish', 'draft']`.
@@ -467,6 +470,8 @@ A post with `post_type='project'` returns a `Project` instance, not a base `Post
 The cached instance state may still hold pre-change values, and a full `save()` will silently overwrite the field the caller just changed. Write the targeted field only (`update_meta`, `update_field`, or `wp_update_post` with one specific field). See [MODELS.md#common-confusions](./docs/MODELS.md#common-confusions).
 
 **Quick reference for the four core model-method traps** — `query()` returns array not builder, `$model->save()` not `wp_update_*`, wrapped accessors not raw keys, vendor-prefixed variable naming — at [MODELS.md#common-confusions](./docs/MODELS.md#common-confusions).
+
+**Quick reference for the five view-system traps** — `$merge` doesn't accumulate, `parent::params($p)` is mandatory, class-string `$defaults` are auto-injected, `$skip_inject` is the DI opt-out, `new My_View()` over `View::render()` — at [VIEW_SYSTEM.md#common-confusions](./docs/VIEW_SYSTEM.md#common-confusions).
 
 **`App::$path` is the App-subclass file's directory, not the plugin root.**
 `App::__construct()` reflects `static::class` to derive `$this->path`. Move `my-plugin.app.php` from `<plugin>/` to `<plugin>/include/` and the autoload root shifts with it. See [AUTOLOADER.md#common-confusions](./docs/AUTOLOADER.md#common-confusions).

--- a/docs/VIEW_SYSTEM.md
+++ b/docs/VIEW_SYSTEM.md
@@ -7,6 +7,7 @@ The Digitalis Framework provides a powerful view system for rendering UI compone
 ## Table of Contents
 
 - [Overview](#overview)
+- [Common Confusions](#common-confusions)
 - [Class Hierarchy](#class-hierarchy)
 - [Static Properties](#static-properties)
 - [Property Inheritance](#property-inheritance)
@@ -72,6 +73,103 @@ Invoice_View::render(['order' => 721, 'user' => 1]);
 - **Type-safe** - Dependency injection validates types
 - **Lifecycle-aware** - Hooks for before/after rendering
 - **Flexible** - Use inline `view()` or external templates
+
+---
+
+## Common Confusions
+
+The traps that bite new agents most often when reaching for the View system. Each entry is a one-line "wrong assumption → reality" with a sketch — full code and rationale live in [ANTIPATTERNS.md](./ANTIPATTERNS.md).
+
+### `$merge` does not accumulate across subclasses — re-list parent keys
+
+**Wrong assumption:** A child class's `$merge` declaration adds to the parent's; only listing new keys is enough.
+**Reality:** `$merge` is replaced wholesale by the child. A child that lists `['styles']` loses parent merging for `'classes'` — `'classes'` quietly becomes overwrite-on-inherit. Re-list every parent key the child still wants merged.
+
+```php
+// ❌ Parent merged 'classes'; child drops it by re-declaring $merge
+class Parent_View extends View {
+    protected static $merge = ['classes'];
+}
+class Child_View extends Parent_View {
+    protected static $merge = ['styles'];   // 'classes' is now overwrite-on-inherit
+}
+
+// ✅ Re-list every key that should keep merging
+class Child_View extends Parent_View {
+    protected static $merge = ['classes', 'styles'];
+}
+```
+
+`$defaults`, `$required`, and `$skip_inject` *do* accumulate up the chain via `Inherits_Props` — `$merge` is the asymmetric one. Full antipattern: [Child views must re-list parent merge keys](./ANTIPATTERNS.md#child-views-must-re-list-parent-merge-keys--they-dont-accumulate).
+
+### `params()` overrides must call `parent::params($p)`
+
+**Wrong assumption:** Overriding `params()` is a clean override; if you don't need parent behaviour you can skip the parent call.
+**Reality:** Parent `params()` is where the inheritance chain's transformations land — `Component` builds its `Element` objects there, intermediate classes set derived fields, etc. Skipping `parent::params($p)` silently drops all of it. There's no error; the view just renders with missing data.
+
+```php
+// ❌ Parent transformations never run
+public function params(&$p) {
+    $p['total'] = $p['order']->get_total();
+}
+
+// ✅
+public function params(&$p) {
+    $p['total'] = $p['order']->get_total();
+    parent::params($p);
+}
+```
+
+The same rule applies to overriding `__construct()` — always call `parent::__construct($params)` first or default-param initialisation never runs. Full antipattern: [Always call `parent::params($p)` when overriding `params()`](./ANTIPATTERNS.md#always-call-parentparamsp-when-overriding-params).
+
+### Class-string `$defaults` are auto-resolved as DI — there is no opt-in
+
+**Wrong assumption:** Setting a default to a class name (`Order::class`) is just a placeholder; the framework only resolves it if you explicitly opt in.
+**Reality:** Any value in `$defaults` that is a string naming a class with a `get_instance()` method is treated as a DI signal. When the caller passes an ID, the framework calls `Order::get_instance($id)` and replaces the param with the instance. This is invisible — there is no flag to flip; injection is the default for class-string defaults.
+
+```php
+// $defaults = ['order' => Order::class]
+new My_View(['order' => 721]);
+// ↓ Framework rewrites in inject_dependencies()
+// $params['order'] = Order::get_instance(721);
+```
+
+This is the feature, not a footgun — but it bites when you intended the class name to *stay* a string. See the next entry.
+
+### `$skip_inject` opts specific keys out of DI
+
+**Wrong assumption:** If a `$defaults` key holds a class name and you want it to remain a literal string (not be injected), there's no way to express that.
+**Reality:** Add the key to `$skip_inject`. Useful when the param is a class *name* the view will instantiate itself, not a model instance the view will read.
+
+```php
+// ❌ Framework calls Order::get_instance($value) — but you wanted a string
+protected static $defaults = [
+    'model_class' => Order::class,
+];
+
+// ✅ Stay a string — the view uses it as a class name, not an instance
+protected static $defaults    = ['model_class' => Order::class];
+protected static $skip_inject = ['model_class'];
+```
+
+`$skip_inject` accumulates up the inheritance chain (unlike `$merge`), so each subclass can add to it without re-listing parent entries. Full antipattern: [Class-name defaults are injected — add to `$skip_inject` to prevent it](./ANTIPATTERNS.md#class-name-defaults-are-injected--add-to-skip_inject-to-prevent-it).
+
+### Instantiate views with `new` — `View::render()` is the legacy static form
+
+**Wrong assumption:** `View::render([...])` is the canonical entry point for rendering a view.
+**Reality:** `View::render()` is supported but not preferred. The framework treats views as objects — instantiate directly with `new`. The `new` form composes uniformly whether you're echoing, casting to string, or storing the view as a value.
+
+```php
+// Supported, but not preferred
+View::render(['param' => 'value']);
+$html = View::render(['param' => 'value'], false);
+
+// ✅ Preferred
+<?= new My_View(['param' => 'value']) ?>
+$html = (string) new My_View(['param' => 'value']);
+```
+
+PHP's `__toString()` is invoked automatically when a view is echoed; the explicit `(string)` cast is only needed when the value is being assigned or passed where the type matters. See [CONVENTIONS — Instantiate views with `new`](./CONVENTIONS.md#instantiate-views-with-new--dont-call-viewrender-statically).
 
 ---
 


### PR DESCRIPTION
## What this changes

Roadmap item: **VIEW_SYSTEM.md — Common Confusions + AGENTS.md surface entries**.

`VIEW_SYSTEM.md` gains a "Common Confusions" section near the top (after Overview, before Class Hierarchy) consolidating the View system's silent-failure modes — a `wrong assumption → reality` sketch for each. `AGENTS.md` Critical Rules is updated per the doc-surfacing pattern: backlinks added to the existing `$merge` and `parent::params($p)` rules, one new entry for the class-string DI / `$skip_inject` pair, plus a "Quick reference for the five view-system traps" pointer mirroring the model-method one. Sub-doc carries depth, AGENTS.md carries the compact pointer — no dedupe.

## Acceptance criteria

- [x] New "Common Confusions" section near the top of `framework/docs/VIEW_SYSTEM.md` — added after Overview, before Class Hierarchy; TOC updated.
- [x] One-line "wrong assumption → reality" entries with brief examples — five entries, each leading with that exact sentence pair plus a short code sketch.
- [x] Covers: `$merge` non-accumulation across subclasses; `parent::params($p)` requirement; `$defaults` class-string DI; `$skip_inject`; `new My_View()` (preferred) vs `View::render()` static — all five present and back-linked to the corresponding [ANTIPATTERNS.md](./docs/ANTIPATTERNS.md) / [CONVENTIONS.md](./docs/CONVENTIONS.md) sections.
- [x] AGENTS.md "Critical Rules" gains 2-3 one-liners, each linked to `VIEW_SYSTEM.md#common-confusions` — one new rule for class-string DI / `$skip_inject`, one new "Quick reference for the five view-system traps" pointer; the existing `$merge` and `parent::params` rules also gained explicit `See [VIEW_SYSTEM.md#common-confusions]` backlinks per the surfacing pattern.

## Antipatterns checked

- [x] No bare `WP_Query` / `get_posts()` / `get_users()` / `get_terms()` at call sites — used framework `query()` methods — N/A (docs only)
- [x] No `wp_update_post` / `wp_update_user` / `wp_update_term` — used `$model->save()` — N/A (docs only)
- [x] No raw meta/field/option key strings at call sites — wrapped in model methods — N/A (docs only)
- [x] If overriding `View::params()`, `parent::params($p)` is called — N/A (no PHP changes; the rule itself is part of what this PR documents)
- [x] If touching `View::$merge`, all parent merge keys are re-listed — N/A (no PHP changes)
- [x] `static::` used for inherited static calls, not `self::` — N/A (no PHP changes)

## Staging exercise

N/A — pure documentation. No runtime surface, no DB mutation.

## Submodule bump

- [x] No follow-up needed
- [ ] Bump required in lattice-test

The lattice-test submodule will pick this up on the next routine bump; no harness exercise depends on it.

## Commit hygiene

- [x] No new files unless required — only `AGENTS.md` and `docs/VIEW_SYSTEM.md` modified
- [x] Commit messages follow `type: description` with 3 storytelling emojis — `🪤🪞🎭`: trap (the confusions), mirror (the surfacing rule — sub-doc reflected up to AGENTS.md), theatre mask (the View system itself).